### PR TITLE
Support Python 3.11 and django 4.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+##[1.5.1]
+### Changed
+- Added support for Python 3.11 and Django 4.2
+
 ##[1.5.0]
 ### Changed
 - Updated the twilio-python dependency to allow >=6.0.0 and <8.0.0

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@ UNMAINTAINED
 ============
 
 **PLEASE NOTE**: this library is not actively maintained and receives
-only minimal updates necessary to make tests pass with newer versions
-of Python and Django.  Most of it is no longer in active use at Ro.
+only minimal updates necessary.  Most of it is no longer in active use
+at Ro.
 
 
 universal\_notifications

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,11 @@
+UNMAINTAINED
+============
+
+**PLEASE NOTE**: this library is not actively maintained and receives
+only minimal updates necessary to make tests pass with newer versions
+of Python and Django.  Most of it is no longer in active use at Ro.
+
+
 universal\_notifications
 ========================
 |travis|_ |pypi|_ |codecov|_

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -1,4 +1,3 @@
-mock>=2.0.0
 pytest>=3.0.4
 pytest-django>=3.1.2
 pytest-cov>=2.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 def pytest_configure():
     from django.conf import settings
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 
     MIDDLEWARE = (
         "django.middleware.common.CommonMiddleware",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework.reverse import reverse
 from tests.test_utils import APIBaseTestCase
 from universal_notifications.models import Device

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-import mock
+from unittest import mock
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.test.utils import override_settings

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -9,7 +9,7 @@
 import json
 from random import randint
 
-import mock
+from unittest import mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from universal_notifications.models import Device, PhoneReceiver, PhoneSent
 
 from .test_utils import APIBaseTestCase

--- a/tests/test_sms_amazonsns.py
+++ b/tests/test_sms_amazonsns.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 from django.test.utils import override_settings
 from tests.test_utils import APIBaseTestCase
 from universal_notifications.backends.sms.utils import send_sms

--- a/tests/test_sms_twilio.py
+++ b/tests/test_sms_twilio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 from django.core import mail
 from django.core.management import call_command
 from django.test.utils import override_settings

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 
 admin.autodiscover()
 
 urlpatterns = [
-    url(r"", include("universal_notifications.urls")),
-    url(r"^admin/", admin.site.urls),
+    re_path(r"", include("universal_notifications.urls")),
+    re_path(r"^admin/", admin.site.urls),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -3,24 +3,23 @@ addopts=--tb=short
 
 [tox]
 envlist =
-    py{38}-lint
-    py{36,37,38,39}-django{220,300,310}
+    py{311}-lint
+    py{39,310,311}-django{32,42}
 
 
 [testenv]
-commands = ./runtests.py --fast {posargs} --coverage -rw
+commands = python runtests.py --fast {posargs} --coverage -rw
 setenv =
     PYTHONDONTWRITEBYTECODE=1
     PYTHONWARNINGS=once
 deps =
-    django220: Django>=2.2,<2.3
-    django300: Django>=3.0,<3.1
-    django310: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
+    django42: Django>=4.2,<4.3
     -rrequirements/requirements-base.txt
     -rrequirements/requirements-testing.txt
 
 [testenv:py38-lint]
-commands = ./runtests.py --lintonly
+commands = python runtests.py --lintonly
 deps =
     -rrequirements/requirements-codestyle.txt
     -rrequirements/requirements-testing.txt

--- a/universal_notifications/__init__.py
+++ b/universal_notifications/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __title__ = "Universal Notifications"
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 __author__ = "Pawel Krzyzaniak"
 __license__ = "MIT"
 __copyright__ = "Copyright 2017-2018 Arabella; 2018+ Ro"

--- a/universal_notifications/api_urls.py
+++ b/universal_notifications/api_urls.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import url
+from django.urls import re_path
 from rest_framework.routers import DefaultRouter
 
 from universal_notifications.api import DeviceDetailsAPI, DevicesAPI, SubscriptionsAPI, UniversalNotificationsDocsView
 from universal_notifications.backends.twilio.api import TwilioAPI
 
 urlpatterns = [
-    url(r"^devices$", DevicesAPI.as_view(), name="notifications-devices"),
-    url(r"^devices/(?P<pk>\d+)$", DeviceDetailsAPI.as_view(), name="device-details"),
-    url(r"^twilio$", TwilioAPI.as_view(), name="twilio-callback"),
-    url(r"^subscriptions$", SubscriptionsAPI.as_view(), name="notifications-subscriptions"),
-    url(r"^api-docs/", UniversalNotificationsDocsView.as_view(), name="notifications-docs"),
+    re_path(r"^devices$", DevicesAPI.as_view(), name="notifications-devices"),
+    re_path(r"^devices/(?P<pk>\d+)$", DeviceDetailsAPI.as_view(), name="device-details"),
+    re_path(r"^twilio$", TwilioAPI.as_view(), name="twilio-callback"),
+    re_path(r"^subscriptions$", SubscriptionsAPI.as_view(), name="notifications-subscriptions"),
+    re_path(r"^api-docs/", UniversalNotificationsDocsView.as_view(), name="notifications-docs"),
 ]
 
 router = DefaultRouter()

--- a/universal_notifications/backends/emails/urls.py
+++ b/universal_notifications/backends/emails/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib.admin.views.decorators import staff_member_required
 
 from universal_notifications.backends.emails.views import FakeEmailSend
 
 urlpatterns = [
-    url(r"$", staff_member_required(FakeEmailSend.as_view()), name="backends.emails.fake_view"),
+    re_path(r"$", staff_member_required(FakeEmailSend.as_view()), name="backends.emails.fake_view"),
 ]

--- a/universal_notifications/models.py
+++ b/universal_notifications/models.py
@@ -4,7 +4,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.signals import post_save
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from phonenumbers import NumberParseException
 
 from universal_notifications.backends.push.apns import apns_send_message
@@ -64,8 +64,8 @@ class Device(models.Model):
         if not self.is_active:
             return False
 
-        message = force_text(message)
-        description = force_text(description)
+        message = force_str(message)
+        description = force_str(description)
         if self.platform == Device.PLATFORM_GCM:
             return gcm_send_message(self, message, data)
         elif self.platform == Device.PLATFORM_IOS:

--- a/universal_notifications/signals.py
+++ b/universal_notifications/signals.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 import django.dispatch
 
-ws_received = django.dispatch.Signal(providing_args=["message_data", "channel_emails"])
+ws_received = django.dispatch.Signal()

--- a/universal_notifications/urls.py
+++ b/universal_notifications/urls.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from rest_framework.routers import DefaultRouter
 
 urlpatterns = [
-    url(r"^emails/", include("universal_notifications.backends.emails.urls")),
-    url(r"api/", include("universal_notifications.api_urls")),
+    re_path(r"^emails/", include("universal_notifications.backends.emails.urls")),
+    re_path(r"api/", include("universal_notifications.api_urls")),
 ]
 
 router = DefaultRouter()


### PR DESCRIPTION
Minimal updates necessary to make tests pass with Python 3.11 and Django 4.2 (LTS).

I tried looking at Python 3.12 but the SSL API changed enough to make that non-trivial, so I'll leave it for later.